### PR TITLE
Add G1 Inspire head-only camera config and fix LeRobot v3 schema

### DIFF
--- a/unitree_lerobot/utils/constants.py
+++ b/unitree_lerobot/utils/constants.py
@@ -268,6 +268,64 @@ G1_INSPIRE_CONFIG = RobotConfig(
 )
 
 
+G1_INSPIRE_HEADONLY_CONFIG = RobotConfig(
+    motors=[
+        "kLeftShoulderPitch",
+        "kLeftShoulderRoll",
+        "kLeftShoulderYaw",
+        "kLeftElbow",
+        "kLeftWristRoll",
+        "kLeftWristPitch",
+        "kLeftWristYaw",
+        "kRightShoulderPitch",
+        "kRightShoulderRoll",
+        "kRightShoulderYaw",
+        "kRightElbow",
+        "kRightWristRoll",
+        "kRightWristPitch",
+        "kRightWristYaw",
+        "kLeftHandPinky",
+        "kLeftHandRing",
+        "kLeftHandMiddle",
+        "kLeftHandIndex",
+        "kLeftHandThumbBend",
+        "kLeftHandThumbRotation",
+        "kRightHandPinky",
+        "kRightHandRing",
+        "kRightHandMiddle",
+        "kRightHandIndex",
+        "kRightHandThumbBend",
+        "kRightHandThumbRotation",
+    ],
+    # 这里只保留一个相机：用 cam_left_high 当作你的头部相机名字
+    cameras=[
+        "cam_left_high",
+    ],
+    # 你的 data.json 里只有 "color_0"，所以只映射这一路
+    camera_to_image_key={
+        "color_0": "cam_left_high",
+        # 下面这些在当前数据里没有，就不要写：
+        # "color_1": "cam_right_high",
+        # "color_2": "cam_left_wrist",
+        # "color_3": "cam_right_wrist",
+    },
+    # 状态和动作字段保持不变（取自 JSON 里的结构）
+    json_state_data_name=[
+        "left_arm.qpos",
+        "right_arm.qpos",
+        "left_ee.qpos",
+        "right_ee.qpos",
+    ],
+    json_action_data_name=[
+        "left_arm.qpos",
+        "right_arm.qpos",
+        "left_ee.qpos",
+        "right_ee.qpos",
+    ],
+)
+
+
+
 MOVEIBLE_LIFT_G1_DEX1_USEWAIST_CONFIG = RobotConfig(
     motors=[
         "kLeftShoulderPitch",
@@ -475,6 +533,9 @@ ROBOT_CONFIGS = {
     "Unitree_G1_Dex3": G1_DEX3_CONFIG,
     "Unitree_G1_Brainco": G1_BRAINCO_CONFIG,
     "Unitree_G1_Inspire": G1_INSPIRE_CONFIG,
+
+    "Unitree_G1_Inspire_HeadOnly": G1_INSPIRE_HEADONLY_CONFIG,  # 新增这一行
+
     "Unitree_G1_MoveibleLift_Dex1_UseWaist": MOVEIBLE_LIFT_G1_DEX1_USEWAIST_CONFIG,
     "Unitree_G1_MoveibleLift_Dex1_NoUseWaist": MOVEIBLE_LIFT_G1_DEX1_NOUSEWAIST_CONFIG,
     "Unitree_G1_Lift_Dex1_UseWaist": LIFT_G1_DEX1_USEWAIST_CONFIG,

--- a/unitree_lerobot/utils/convert_unitree_json_to_lerobot.py
+++ b/unitree_lerobot/utils/convert_unitree_json_to_lerobot.py
@@ -222,16 +222,16 @@ def create_empty_dataset(
         "observation.state": {
             "dtype": "float32",
             "shape": (len(motors),),
-            "names": [
-                motors,
-            ],
+            "names": {
+                "motors": motors,      # ← 正确格式：dict，而不是 list
+            },
         },
         "action": {
             "dtype": "float32",
             "shape": (len(motors),),
-            "names": [
-                motors,
-            ],
+            "names": {
+                "motors": motors,      # ← 正确格式：dict，而不是 list
+             },
         },
     }
 
@@ -239,18 +239,18 @@ def create_empty_dataset(
         features["observation.velocity"] = {
             "dtype": "float32",
             "shape": (len(motors),),
-            "names": [
-                motors,
-            ],
+            "names": {
+                "motors": motors,      # ← 正确格式：dict，而不是 list
+            },
         }
 
     if has_effort:
         features["observation.effort"] = {
             "dtype": "float32",
             "shape": (len(motors),),
-            "names": [
-                motors,
-            ],
+            "names": {
+                "motors": motors,      # ← 正确格式：dict，而不是 list
+            },
         }
 
     for cam in cameras:
@@ -316,7 +316,7 @@ def populate_dataset(
 def json_to_lerobot(
     raw_dir: Path,
     repo_id: str,
-    robot_type: str,  # e.g., Unitree_Z1_Single, Unitree_Z1_Dual, Unitree_G1_Dex1, Unitree_G1_Dex3, Unitree_G1_Brainco, Unitree_G1_Inspire
+    robot_type: str,  # e.g., Unitree_Z1_Single, Unitree_Z1_Dual, Unitree_G1_Dex1, Unitree_G1_Dex3, Unitree_G1_Brainco, Unitree_G1_Inspire,Unitree_G1_Inspire_HeadOnly
     *,
     push_to_hub: bool = False,
     mode: Literal["video", "image"] = "video",


### PR DESCRIPTION
This PR mainly includes two changes:

1. **Add support for G1 Inspire head-only camera setup**
   - Add `Unitree_G1_Inspire_HeadOnly` config in `unitree_lerobot/utils/constants.py`
   - Only use `cam_left_high` mapped from `color_0` for head camera
   - Keep motor names consistent with G1 Inspire robot

2. **Fix dataset format to be compatible with LeRobot 3.0**
   - Update `convert_unitree_json_to_lerobot.py` to match the new `features["observation.state"]["names"]` dict format (with `"motors"` key)
   - Ensure generated dataset passes `validate_frame` without missing image features when only head camera exists