### PR TITLE
fix: add missing rename_map field to EvalRealConfig

### DIFF
--- a/unitree_lerobot/eval_robot/utils/sim_savedata_utils.py
+++ b/unitree_lerobot/eval_robot/utils/sim_savedata_utils.py
@@ -8,7 +8,7 @@ from unitree_lerobot.eval_robot.utils.utils import (
 from unitree_lerobot.eval_robot.make_robot import (
     publish_reset_category,
 )
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from lerobot.configs import parser
 from lerobot.configs.policies import PreTrainedConfig
 import time
@@ -190,6 +190,7 @@ class EvalRealConfig:
     save_data: bool = False
     task_dir: str = "./data"
     max_episodes: int = 1200
+    rename_map: dict[str, str] = field(default_factory=dict)
 
     def __post_init__(self):
         # HACK: We parse again the cli args here to get the pretrained path if there was one.


### PR DESCRIPTION
## Summary

Fixes #60

`EvalRealConfig` in `sim_savedata_utils.py` was missing the `rename_map` field that is accessed by `eval_g1_sim.py`. Running `eval_g1_sim.py` would raise an `AttributeError` immediately at the point where the policy is initialized:

```
AttributeError: 'EvalRealConfig' object has no attribute 'rename_map'
```

Traced to these two lines in `eval_g1_sim.py`:
```python
# line 249
dataset_stats=rename_stats(dataset.meta.stats, cfg.rename_map),
# line 252
"rename_observations_processor": {"rename_map": cfg.rename_map},
```

## Changes

**`unitree_lerobot/eval_robot/utils/sim_savedata_utils.py`**

1. Added `field` to the existing `dataclasses` import:
```python
# Before
from dataclasses import dataclass

# After
from dataclasses import dataclass, field
```

2. Added the missing field to `EvalRealConfig`:
```python
rename_map: dict[str, str] = field(default_factory=dict)
```

This matches the identical field already present in `utils/utils.py` for the real-robot config, and defaults to an empty dict (no renames) so existing usage is unaffected.

## Test plan
- [ ] Run `eval_g1_sim.py` without `--rename_map` arg → should no longer raise `AttributeError`
- [ ] Run with a `rename_map` override → mapping should be passed through to `rename_stats` and `rename_observations_processor`