### PR TITLE
Fix logging_mp version incompatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "matplotlib>=3.9.0",
     "meshcat==0.3.2",
     # "unitree_sdk2py @ git+https://github.com/unitreerobotics/unitree_sdk2_python.git@master",
-    "logging_mp"
+    "logging_mp>=0.1.0,<0.2.0"
 ]
 
 [tool.setuptools]

--- a/unitree_lerobot/eval_robot/utils/rerun_visualizer.py
+++ b/unitree_lerobot/eval_robot/utils/rerun_visualizer.py
@@ -145,13 +145,13 @@ class RerunLogger:
             state_tensor = step_data[self._state_key]
             entity_path = f"{self.prefix}state"
             for i, val in enumerate(state_tensor):
-                rr.log(f"{entity_path}/joint_{i}", rr.Scalar(val.item()))
+                rr.log(f"{entity_path}/joint_{i}", rr.Scalars(val.item()))
 
         if self._action_key in step_data:
             action_tensor = step_data[self._action_key]
             entity_path = f"{self.prefix}action"
             for i, val in enumerate(action_tensor):
-                rr.log(f"{entity_path}/joint_{i}", rr.Scalar(val.item()))
+                rr.log(f"{entity_path}/joint_{i}", rr.Scalars(val.item()))
 
 
 def visualization_data(idx, observation, state, action, online_logger):


### PR DESCRIPTION
When running eval_g1_sim.py the error `AttributeError: module 'logging_mp' has no attribute 'get_logger'. Did you mean: 'getLogger'?` can occur. 

When logging_mp upgraded from 0.1.6 to 0.2.0 it introduced breaking changes. Currently, the pyproject.toml uses the latest version if it is not installed already, which is not compatible.

Also mentioned in issue #70 