### PR TITLE
Fix logging_mp version incompatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "matplotlib>=3.9.0",
     "meshcat==0.3.2",
     # "unitree_sdk2py @ git+https://github.com/unitreerobotics/unitree_sdk2_python.git@master",
-    "logging_mp"
+    "logging_mp>=0.1.0,<0.2.0"
 ]
 
 [tool.setuptools]


### PR DESCRIPTION
When running eval_g1_sim.py the error `AttributeError: module 'logging_mp' has no attribute 'get_logger'. Did you mean: 'getLogger'?` can occur. 

When logging_mp upgraded from 0.1.6 to 0.2.0 it introduced breaking changes. Currently, the pyproject.toml uses the latest version if it is not installed already, which is not compatible.

Also mentioned in issue #70 


_Edit: Sorry, opened a pull request from the wrong branch at first_