### PR TITLE
Fix usage of rerun.Scalar

### DIFF
--- a/unitree_lerobot/eval_robot/utils/rerun_visualizer.py
+++ b/unitree_lerobot/eval_robot/utils/rerun_visualizer.py
@@ -145,13 +145,13 @@ class RerunLogger:
             state_tensor = step_data[self._state_key]
             entity_path = f"{self.prefix}state"
             for i, val in enumerate(state_tensor):
-                rr.log(f"{entity_path}/joint_{i}", rr.Scalar(val.item()))
+                rr.log(f"{entity_path}/joint_{i}", rr.Scalars(val.item()))
 
         if self._action_key in step_data:
             action_tensor = step_data[self._action_key]
             entity_path = f"{self.prefix}action"
             for i, val in enumerate(action_tensor):
-                rr.log(f"{entity_path}/joint_{i}", rr.Scalar(val.item()))
+                rr.log(f"{entity_path}/joint_{i}", rr.Scalars(val.item()))
 
 
 def visualization_data(idx, observation, state, action, online_logger):


### PR DESCRIPTION
When evaluating a policy with `--visualization=true`, then the eval_g1_sim.py (and other scripts) crash, as the rerun_visualizer uses some type names from an older version.

rerun.Scalar was changed to rerun.Scalars before the minimum required version of rerun-sdk>=0.24.0 which is specified by the lerobot repository commit that is included as submodule.