### PR TITLE
fix: Correct LeRobot datset export schema

### DIFF
--- a/unitree_lerobot/utils/convert_unitree_json_to_lerobot.py
+++ b/unitree_lerobot/utils/convert_unitree_json_to_lerobot.py
@@ -222,16 +222,12 @@ def create_empty_dataset(
         "observation.state": {
             "dtype": "float32",
             "shape": (len(motors),),
-            "names": [
-                motors,
-            ],
+            "names": motors,
         },
         "action": {
             "dtype": "float32",
             "shape": (len(motors),),
-            "names": [
-                motors,
-            ],
+            "names": motors,
         },
     }
 
@@ -239,18 +235,14 @@ def create_empty_dataset(
         features["observation.velocity"] = {
             "dtype": "float32",
             "shape": (len(motors),),
-            "names": [
-                motors,
-            ],
+            "names": motors,
         }
 
     if has_effort:
         features["observation.effort"] = {
             "dtype": "float32",
             "shape": (len(motors),),
-            "names": [
-                motors,
-            ],
+            "names": motors,
         }
 
     for cam in cameras:


### PR DESCRIPTION
The conversion script wraps the 'motors' list in another list, leading to incorrect parsing in downstream usage. This fix exports the motor names correctly as a flat list.